### PR TITLE
[3주차] 박상희

### DIFF
--- a/SANGHEE_PARK/week03/boj_11399_ATM.java.java
+++ b/SANGHEE_PARK/week03/boj_11399_ATM.java.java
@@ -1,0 +1,32 @@
+package org.example.week03;
+
+import java.util.*;
+import java.io.*;
+
+//boj_11399_ATM.java
+public class Boj11399 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+        int[] arr = new int[N];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        // 오름차순 정렬
+        Arrays.sort(arr);
+
+        int sum = 0;
+        int total = 0;
+
+        for (int i = 0; i < N; i++) {
+            sum += arr[i];   // 현재까지 누적 대기시간
+            total += sum;    // 전체 합
+        }
+
+        System.out.println(total);
+    }
+}

--- a/SANGHEE_PARK/week03/boj_1260_DFS와 BFS.java.java
+++ b/SANGHEE_PARK/week03/boj_1260_DFS와 BFS.java.java
@@ -1,0 +1,83 @@
+package org.example.week03;
+
+import java.util.*;
+import java.io.*;
+
+//boj_1260_DFS와 BFS.java
+public class Boj1260 {
+    static ArrayList<Integer>[] graph;
+    static boolean[] visited;
+    static StringBuilder sb = new StringBuilder();
+
+    // DFS
+    static void dfs(int v) {
+        visited[v] = true;
+        sb.append(v).append(" ");
+
+        for (int next : graph[v]) {
+            if (!visited[next]) {
+                dfs(next);
+            }
+        }
+    }
+
+    // BFS
+    static void bfs(int start) {
+        Queue<Integer> queue = new LinkedList<>();
+        visited[start] = true;
+        queue.offer(start);
+
+        while (!queue.isEmpty()) {
+            int now = queue.poll();
+            sb.append(now).append(" ");
+
+            for (int next : graph[now]) {
+                if (!visited[next]) {
+                    visited[next] = true;
+                    queue.offer(next);
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken()); // 정점의 개수
+        int M = Integer.parseInt(st.nextToken()); // 간선의 개수
+        int V = Integer.parseInt(st.nextToken()); // 시작 정점
+
+        graph = new ArrayList[N + 1];
+        visited = new boolean[N + 1];
+
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        // 간선 입력
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            graph[a].add(b);
+            graph[b].add(a);
+        }
+
+        // 번호가 작은 정점부터 방문하기 위해 정렬
+        for (int i = 1; i <= N; i++) {
+            Collections.sort(graph[i]);
+        }
+
+        // DFS 실행
+        dfs(V);
+        sb.append("\n");
+
+        // visited 배열 초기화 후 BFS 실행
+        visited = new boolean[N + 1];
+        bfs(V);
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
**1260 - DFS와 BFS**

🤔 **접근 방법**

다른 사람 코드 / AI 활용 여부 [Y]

알고리즘

* DFS
* BFS
* 그래프 (인접 리스트)

설명

* 정점의 개수 N, 간선의 개수 M, 시작 정점 V 입력
* 인접 리스트를 이용해 그래프 구성
* 양방향 그래프이므로 a-b, b-a 모두 추가
* 각 정점의 연결 리스트를 오름차순 정렬 (문제 조건)
* DFS는 재귀를 이용해 방문
* BFS는 Queue를 이용해 방문
* 방문 여부를 체크하기 위해 visited 배열 사용
* DFS 수행 후 visited 배열 초기화 후 BFS 수행

✏️ **구현 (핵심 코드)**

```java
static void dfs(int v) {
    visited[v] = true;
    sb.append(v).append(" ");

    for (int next : graph[v]) {
        if (!visited[next]) {
            dfs(next);
        }
    }
}

static void bfs(int start) {
    Queue<Integer> queue = new LinkedList<>();
    visited[start] = true;
    queue.offer(start);

    while (!queue.isEmpty()) {
        int now = queue.poll();
        sb.append(now).append(" ");

        for (int next : graph[now]) {
            if (!visited[next]) {
                visited[next] = true;
                queue.offer(next);
            }
        }
    }
}
```

✔️ **배운 점**

* DFS는 재귀, BFS는 큐를 이용한다는 차이를 이해했다.
* 그래프 문제에서 방문 순서를 맞추기 위해 정렬이 필요할 수 있다는 점을 알게 되었다.
* visited 배열을 적절히 초기화해야 여러 탐색을 수행할 수 있다.

---
**11399 - ATM**

🤔 **접근 방법**

다른 사람 코드 / AI 활용 여부 [N]

알고리즘

* 그리디
* 정렬

설명

* 사람 수 N 입력
* 각 사람이 돈을 인출하는 데 걸리는 시간 배열 입력
* 전체 대기 시간의 합을 최소로 하기 위해 오름차순 정렬
* 앞 사람의 시간이 뒤 사람에게 누적되므로 누적합 계산
* 누적합을 계속 더하여 총 대기시간 계산

✏️ **구현 (핵심 코드)**

```java
Arrays.sort(arr);

int sum = 0;
int total = 0;

for (int i = 0; i < N; i++) {
    sum += arr[i];
    total += sum;
}
```

✔️ **배운 점**

* 그리디 알고리즘에서 정렬을 통해 최적의 해를 만들 수 있다는 점을 이해했다.
* 누적합을 활용하면 시간 복잡도를 줄이면서 계산할 수 있다.
* 문제의 핵심은 "작은 값부터 처리"라는 전략이라는 것을 배웠다.

---
