### PR TITLE
[7주차] 남해림

### DIFF
--- a/HAERIM_NAM/week07/pgs_42576_완주하지 못한 선수.java
+++ b/HAERIM_NAM/week07/pgs_42576_완주하지 못한 선수.java
@@ -1,0 +1,23 @@
+import java.util.HashMap;
+
+class Solution {
+    public String solution(String[] participant, String[] completion) {
+        HashMap<String, Integer> map = new HashMap<>();
+
+        for (String name : participant) {
+            map.put(name, map.getOrDefault(name, 0) + 1);
+        }
+
+        for (String name : completion) {
+            map.put(name, map.get(name) - 1);
+        }
+
+        for (String key : map.keySet()) {
+            if (map.get(key) > 0) {
+                return key;
+            }
+        }
+
+        return "";
+    }
+}

--- a/HAERIM_NAM/week07/pgs_43162_네트워크.java
+++ b/HAERIM_NAM/week07/pgs_43162_네트워크.java
@@ -1,0 +1,29 @@
+class Solution {
+
+    boolean[] visited;
+
+    public int solution(int n, int[][] computers) {
+        visited = new boolean[n];
+
+        int answer = 0;
+
+        for (int i = 0; i < n; i++) {
+            if (!visited[i]) {
+                dfs(i, computers);
+                answer++;
+            }
+        }
+
+        return answer;
+    }
+
+    public void dfs(int node, int[][] computers) {
+        visited[node] = true;
+
+        for (int i = 0; i < computers.length; i++) {
+            if (computers[node][i] == 1 && !visited[i]) {
+                dfs(i, computers);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### **42576 - 완주하지 못한 선수**

🤔 **접근 방법**

다른 사람 코드 / AI 활용 여부 [N]

알고리즘

- 해시맵 (HashMap)
- 문자열 탐색

설명

- 참가자 이름과 등장 횟수를 `HashMap`에 저장하였다.
- 참가자 배열을 순회하면서 이름이 나오면 개수를 증가시키고, 완주자 배열을 순회하면서 해당 이름의 개수를 감소시켰다.
- 동명이인이 존재할 수 있으므로 단순 포함 여부가 아닌 등장 횟수를 저장해야 한다.
- 모든 완주자 처리 후 값이 0보다 큰 사람(완주하지 못한 선수)의 이름을 반환하였다.

✏️ **구현 (핵심 코드)**

```
for (String name : participant) {
    map.put(name, map.getOrDefault(name, 0) + 1);
}

for (String name : completion) {
    map.put(name, map.get(name) - 1);
}

for (String key : map.keySet()) {
    if (map.get(key) > 0) {
        return key;
    }
}
```

✔️ 배운 점

- 동명이인이 존재하는 경우, 단순 비교가 아닌 개수 기반으로 처리해야 함을 배웠다.
- `getOrDefault()`를 사용하면 키 존재 여부를 따로 확인하지 않아도 된다는 점을 배웠다.

---

### **43162 - 네트워크**

🤔 **접근 방법**

다른 사람 코드 / AI 활용 여부 [Y]

알고리즘

- 그래프 탐색
- 깊이 우선 탐색 (DFS)

설명

- 컴퓨터 간 연결 정보를 그래프라고 생각하고 DFS를 수행하였다.
- 아직 방문하지 않은 컴퓨터를 발견하면 해당 컴퓨터를 시작점으로 DFS를 수행하여 연결된 모든 컴퓨터를 방문 처리하였다.
- DFS가 한 번 끝날 때마다 하나의 네트워크를 모두 탐색한 것이므로 네트워크 개수를 1 증가시켰다.
- 모든 컴퓨터를 확인한 뒤 DFS가 수행된 횟수가 최종 네트워크 개수가 된다.

✏️ **구현 (핵심 코드)**

```
for (int i = 0; i < n; i++) {
    if (!visited[i]) {
        dfs(i, computers);
        answer++;
    }
}

public void dfs(int node, int[][] computers) {
    visited[node] = true;

    for (int i = 0; i < computers.length; i++) {
        if (computers[node][i] == 1 && !visited[i]) {
            dfs(i, computers);
        }
    }
}
```

✔️ 배운 점

- 연결된 컴퓨터들을 하나의 그래프로 볼 수 있다는 점을 알게 되었다.
- 방문 배열을 사용하면 이미 탐색한 컴퓨터를 다시 방문하지 않기 때문에 효율적으로 탐색할 수 있었다.